### PR TITLE
Proper error handling when authorization failed

### DIFF
--- a/imgur_python/Exceptions.py
+++ b/imgur_python/Exceptions.py
@@ -1,0 +1,18 @@
+
+class ImgurException(Exception):
+    """ Base exception class for Imgur-Python """
+
+class ImgurBadRequest(ImgurException):
+    """ Raised when a request is returned with HTTP 400: Bad Request """
+
+class ImgurUnauthorized(ImgurException):
+    """ Raised when a request is returned with HTTP 401: Unauthorized """
+
+class ImgurForbidden(ImgurException):
+    """ Raised when a request is returned with HTTP 403: Forbidden """
+
+ExceptionLUT = {
+    400 : ImgurBadRequest,
+    401 : ImgurUnauthorized,
+    403 : ImgurForbidden,
+}

--- a/imgur_python/ImgurBase.py
+++ b/imgur_python/ImgurBase.py
@@ -4,6 +4,8 @@
 Base class
 """
 
+from .Exceptions import ExceptionLUT, ImgurException
+
 
 class ImgurBase():
     "Basic methods"
@@ -17,7 +19,8 @@ class ImgurBase():
         if request.status_code == 200:
             response['response'] = request.json()
         else:
-            response['response'] = request
+            raise ExceptionLUT.get(request.status_code, ImgurException) \
+                     (request.status_code, request.reason)
         return response
 
     @staticmethod
@@ -27,4 +30,5 @@ class ImgurBase():
             response = request.json()
             return response['data']
         else:
-            return None
+            raise ExceptionLUT.get(request.status_code, ImgurException) \
+                     (request.status_code, request.reason)


### PR DESCRIPTION
Currently only the "[Sunny day scenario](https://en.wikipedia.org/wiki/Happy_path)" is properly handled. The code that handles deviations from that path has a couple of flaws. In this case: if we did not authorize, the code that handles the 403 code breaks other classes.

This PR fixes this scenario by raising the appropriate Exception. 
I took the liberty of adding a basic Exceptions.py file in which all Exceptions for this library can be contained. For now it's just the most common HTTP error codes, but this can be extended in the future. 

This PR also fixes a small typo: `null` instead of `None`. I'm assuming the original author is more used to C than Python? :)